### PR TITLE
Pperf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.o
 *.a
 *.so
+*.out
 
 # Folders
 _obj
@@ -23,6 +24,7 @@ _testmain.go
 *.exe
 *.test
 *.prof
+bench*
 
 # Emacs
 *~

--- a/empty.go
+++ b/empty.go
@@ -2,9 +2,9 @@ package jutil
 
 import "reflect"
 
-// IsEmptyTells is returns true if the value given as argument would be
-// considered empty by the standard json package, and therefore not serialized
-// if `omitempty` is set on a struct field with this value.
+// IsEmptyValue returns true if the value given as argument would be considered
+// empty by the standard json package, and therefore not serialized if
+// `omitempty` is set on a struct field with this value.
 func IsEmptyValue(v interface{}) bool {
 	return isEmptyValue(reflect.ValueOf(v))
 }

--- a/jutil_test.go
+++ b/jutil_test.go
@@ -1,0 +1,27 @@
+package jutil
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"testing"
+)
+
+var benchLengthFunc func(interface{})
+
+func TestMain(m *testing.M) {
+	var benchLength string
+
+	flag.StringVar(&benchLength, "bench-length", "Length", "the length function to benchmark")
+	flag.Parse()
+
+	switch benchLength {
+	case "json.Marshal":
+		benchLengthFunc = func(v interface{}) { json.Marshal(v) }
+
+	default:
+		benchLengthFunc = func(v interface{}) { Length(v) }
+	}
+
+	os.Exit(m.Run())
+}

--- a/length.go
+++ b/length.go
@@ -16,7 +16,7 @@ type Lengther interface {
 }
 
 // Length computes the length of the JSON representation of a value of
-// arbitrary type, it's ~2x faster than serializing the content with the
+// arbitrary type, it's ~10x faster than serializing the content with the
 // standard json package and avoid the extra memory allocations.
 func Length(v interface{}) (n int, err error) {
 	var b []byte

--- a/length.go
+++ b/length.go
@@ -284,23 +284,12 @@ func jsonLenMap(v reflect.Value) (n int, err error) {
 
 func jsonLenStruct(t reflect.Type, v reflect.Value) (n int, err error) {
 	var c int
+	var s = structCache.Lookup(t)
 
-	for i, j := 0, t.NumField(); i != j; i++ {
-		ft := t.Field(i)
+	for _, f := range s {
+		fv := v.FieldByIndex(f.Index)
 
-		if len(ft.PkgPath) != 0 && !ft.Anonymous { // unexported
-			continue
-		}
-
-		tag := ParseStructField(ft)
-
-		if tag.Skip {
-			continue
-		}
-
-		fv := v.Field(i)
-
-		if tag.Omitempty && isEmptyValue(fv) {
+		if f.Omitempty && isEmptyValue(fv) {
 			continue
 		}
 
@@ -312,7 +301,7 @@ func jsonLenStruct(t reflect.Type, v reflect.Value) (n int, err error) {
 			n++
 		}
 
-		n += jsonLenString(tag.Name) + c + 1
+		n += jsonLenString(f.Name) + c + 1
 	}
 
 	n += 2

--- a/struct.go
+++ b/struct.go
@@ -1,0 +1,110 @@
+package jutil
+
+import (
+	"reflect"
+	"sync"
+)
+
+// Struct is used to represent a Go structure in internal data structures that
+// cache meta information to make field lookups faster and avoid having to use
+// reflection to lookup the same type information over and over again.
+type Struct []StructField
+
+// MakeStruct takes a Go type as argument and extract information to make a new
+// Struct value.
+// The type has to be a struct type or a panic will be raised.
+func MakeStruct(t reflect.Type) Struct {
+	n := t.NumField()
+	s := make(Struct, 0, n)
+
+	for i := 0; i != n; i++ {
+		if f := MakeStructField(t.Field(i)); !f.Skip {
+			s = append(s, f)
+		}
+	}
+
+	return s
+}
+
+// StructField represents a single field of a struct and carries information
+// useful to the algorithms of the jutil package.
+type StructField struct {
+	// The index of the field in the structure.
+	Index []int
+
+	// The name of the field once serialized to JSON.
+	Name string
+
+	// True if the field has to be omitted when it has an empty value.
+	Omitempty bool
+
+	// True if the field should be skipped entirely.
+	Skip bool
+}
+
+// MakeStructField takes a Go struct field as argument argument and returns its
+// StructType representation.
+func MakeStructField(f reflect.StructField) StructField {
+	tag := ParseStructField(f)
+
+	field := StructField{
+		Index:     f.Index,
+		Name:      tag.Name,
+		Omitempty: tag.Omitempty,
+		Skip:      tag.Skip,
+	}
+
+	if len(f.PkgPath) != 0 && !f.Anonymous { // unexported
+		field.Skip = true
+	}
+
+	return field
+}
+
+// StructCache is a simple cache for mapping Go types to Struct values.
+type StructCache struct {
+	mutex sync.RWMutex
+	store map[reflect.Type]Struct
+}
+
+// NewStructCache creates and returns a new StructCache value.
+func NewStructCache() *StructCache {
+	return &StructCache{
+		store: make(map[reflect.Type]Struct),
+	}
+}
+
+// Lookup takes a Go type as argument and returns the matching Struct value,
+// potentially creating it if it didn't already exist.
+func (cache *StructCache) Lookup(t reflect.Type) (s Struct) {
+	cache.mutex.RLock()
+	s = cache.store[t]
+	cache.mutex.RUnlock()
+
+	if s == nil {
+		s = MakeStruct(t)
+		cache.mutex.Lock()
+		cache.store[t] = s
+		cache.mutex.Unlock()
+	}
+
+	return
+}
+
+var (
+	// This struct cache is used to avoid reusing reflection over and over when
+	// the jutil functions are called. The performance improvements on iterating
+	// over struct fields are huge, this is a really important optimization:
+	//
+	// benchmark                                   old ns/op     new ns/op     delta
+	// BenchmarkLengthStructZero                   53.9          99.9          +85.34%
+	// BenchmarkLengthStructNonZero                746           411           -44.91%
+	// BenchmarkLengthStructOmitEmptyZero          779           174           -77.66%
+	// BenchmarkLengthStructOmpitemptytNonZero     1119          425           -62.02%
+	//
+	// Note: Disregard the performance loss on the `StructZero` benchmark, this
+	// is testing an empty struct with no field, which is just a baseline and not
+	// actually useful in real-world use cases.
+	//
+	structCache = NewStructCache()
+)

--- a/struct_test.go
+++ b/struct_test.go
@@ -1,0 +1,38 @@
+package jutil
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMakeStructField(t *testing.T) {
+	tests := []struct {
+		s reflect.StructField
+		f StructField
+	}{
+		{
+			s: reflect.TypeOf(struct{ A int }{}).Field(0),
+			f: StructField{
+				Index:     []int{0},
+				Name:      "A",
+				Omitempty: false,
+				Skip:      false,
+			},
+		},
+		{
+			s: reflect.TypeOf(struct{ a int }{}).Field(0),
+			f: StructField{
+				Index:     []int{0},
+				Name:      "a",
+				Omitempty: false,
+				Skip:      true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		if f := MakeStructField(test.s); !reflect.DeepEqual(test.f, f) {
+			t.Errorf("%#v != %#v", test.f, f)
+		}
+	}
+}


### PR DESCRIPTION
I decoupled the benchmarks and did more accurate comparisons with the standard library, then made a couple of improvements that got the `Length` function from ~2x to ~10x faster than the standard JSON encoder:

```
benchmark                                    old ns/op     new ns/op     delta
BenchmarkLengthBoolZero                      307           17.9          -94.17%
BenchmarkLengthBoolNonZero                   317           17.6          -94.45%
BenchmarkLengthIntZero                       330           21.6          -93.45%
BenchmarkLengthIntNonZero                    350           34.0          -90.29%
BenchmarkLengthFloatZero                     371           86.8          -76.60%
BenchmarkLengthFloatNonZero                  522           250           -52.11%
BenchmarkLengthStringZero                    325           24.7          -92.40%
BenchmarkLengthStringNonZero                 1052          933           -11.31%
BenchmarkLengthBytesZero                     377           22.3          -94.08%
BenchmarkLengthBytesNonZero                  1145          22.5          -98.03%
BenchmarkLengthSliceInterfaceZero            326           25.8          -92.09%
BenchmarkLengthSliceInterfaceNonZero         337           25.6          -92.40%
BenchmarkLengthSliceBoolZero                 331           62.6          -81.09%
BenchmarkLengthSliceBoolNonZero              943           846           -10.29%
BenchmarkLengthTimeZero                      1090          531           -51.28%
BenchmarkLengthTimeNonZero                   1254          574           -54.23%
BenchmarkLengthDurationZero                  333           68.4          -79.46%
BenchmarkLengthDurationNonZero               361           91.6          -74.63%
BenchmarkLengthMapStringInterfaceZero        507           19.4          -96.17%
BenchmarkLengthMapStringInterfaceNonZero     5783          843           -85.42%
BenchmarkLengthMapStringStringZero           504           165           -67.26%
BenchmarkLengthMapStringStringNonZero        4848          3649          -24.73%
BenchmarkLengthStructZero                    326           99.1          -69.60%
BenchmarkLengthStructNonZero                 668           415           -37.87%
BenchmarkLengthStructOmitEmptyZero           411           177           -56.93%
BenchmarkLengthStructOmpitemptytNonZero      700           430           -38.57%
```
