### PR TITLE
Fix typo in empty_test

### DIFF
--- a/empty_test.go
+++ b/empty_test.go
@@ -21,7 +21,7 @@ func TestIsEmptyTrue(t *testing.T) {
 	}
 }
 
-func TestIsEmptyFale(t *testing.T) {
+func TestIsEmptyFalse(t *testing.T) {
 	tests := []interface{}{
 		true,
 		1,


### PR DESCRIPTION
Hey there!
I was taking a look at the JSON Utils and found a small typo in `empty_test` - not a big deal, but I thought it'd be ok fixing it.

Cheers